### PR TITLE
fix: stabilize slider interval

### DIFF
--- a/src/components/PresentacionSlider.tsx
+++ b/src/components/PresentacionSlider.tsx
@@ -1,5 +1,5 @@
 // src/components/PresentacionSlider.tsx
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import '../styles/PresentacionSlider.css';
 
 const images = [
@@ -11,9 +11,9 @@ const images = [
 const PresentacionSlider = () => {
   const [current, setCurrent] = useState(0);
 
-  const nextSlide = () => {
+  const nextSlide = useCallback(() => {
     setCurrent((prev) => (prev + 1) % images.length);
-  };
+  }, []);
 
   const prevSlide = () => {
     setCurrent((prev) => (prev - 1 + images.length) % images.length);
@@ -25,11 +25,9 @@ const PresentacionSlider = () => {
 
   // Auto-slide
   useEffect(() => {
-    const interval = setInterval(() => {
-      nextSlide();
-    }, 5000);
+    const interval = setInterval(nextSlide, 5000);
     return () => clearInterval(interval);
-  }, []);
+  }, [nextSlide]);
 
   return (
     <div className="slider-container">


### PR DESCRIPTION
## Summary
- stabilize auto-slide by memoizing `nextSlide`
- ensure interval cleanup on unmount

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68917db412bc83269e0875f656e7b433