### PR TITLE
Fix invalid h1 font-weight

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -164,7 +164,7 @@ logo.arquitectura {
 /* textos */
 h1 {
   font-size: 24px;
-  font-weight: 1px;
+  font-weight: 400;
   margin: 30px 0;
   color: rgba(32, 20, 61, 0.651);
 }


### PR DESCRIPTION
## Summary
- fix invalid font-weight value for h1 in main stylesheet

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891818aff508326857d386db067bf7b