### PR TITLE
Use video ref for Diapo2 playback

### DIFF
--- a/src/components/Diapositivas/Diapo2.tsx
+++ b/src/components/Diapositivas/Diapo2.tsx
@@ -1,22 +1,32 @@
 // src/components/Diapositivas/Diapo2.tsx
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 type Props = {
   onFinish: () => void;
 };
 
 export default function Diapo2({ onFinish }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
   useEffect(() => {
-    const video = document.getElementById('video-diapo2') as HTMLVideoElement;
+    const video = videoRef.current;
     if (video) {
       video.play();
-      video.onended = onFinish;
+      video.addEventListener('ended', onFinish);
+      return () => {
+        video.removeEventListener('ended', onFinish);
+      };
     }
   }, [onFinish]);
 
   return (
     <div className="slide">
-      <video id="video-diapo2" src="/video/video.mp4" controls style={{ width: '100%' }} />
+      <video
+        ref={videoRef}
+        src="/video/video.mp4"
+        controls
+        style={{ width: '100%' }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use React ref to control Diapo2 video
- attach and clean up `ended` listener

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68918196ae4c83269a073c887dba92c6